### PR TITLE
Better feature detection for callability

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-export default p => p instanceof Function
+export default p => typeof p === "function"
     ? p                     // fn
     : typeof p === 'string'
         ? obj => obj[p]     // property name


### PR DESCRIPTION
JavaScript callable objects need not have prototype `Function.prototype`. For instance:
```js
let f1 = Reflect.construct(Function, [
      "console.log('called f1', arguments[0]);"
   ],
   Object
);
function f2 (x) {
   console.log('called f2', x);
}
Object.setPrototypeOf(f2, Object.prototype);
```
Neither `f1` nor `f2` is an `instanceof Function`. But they are both callable. Internally, a JavaScript variable is Callable if it is an `Object` that has an internal `[[Call]]` method:
https://262.ecma-international.org/6.0/#sec-iscallable

Any `Object` with an internal `[[Call]]` method will have `typeof x === "function"`: 
https://262.ecma-international.org/6.0/#sec-typeof-operator 

So according to the JS language spec checking for `typeof x === "function"` can never have  a false negative, unlike `x instanceof Function`.

@webReflection